### PR TITLE
Restore form and connect Formspree

### DIFF
--- a/index.html
+++ b/index.html
@@ -316,22 +316,22 @@
                 <h2>Забронируйте Ваше Место на Воркшопе</h2>
                 <p>Заполните форму ниже, и мы свяжемся с вами для подтверждения участия</p>
                 
-                <form class="registration-form" id="registrationForm">
+                <form class="registration-form" id="registrationForm" action="https://formspree.io/f/xvgrrpan" method="POST">
                     <div class="form-group">
                         <label for="name">Ваше имя *</label>
                         <input type="text" id="name" name="name" required>
                     </div>
-                    
+
                     <div class="form-group">
                         <label for="email">Email *</label>
                         <input type="email" id="email" name="email" required>
                     </div>
-                    
+
                     <div class="form-group">
                         <label for="phone">Телефон *</label>
                         <input type="tel" id="phone" name="phone" required>
                     </div>
-                    
+
                     <div class="form-group">
                         <label for="business">Тип бизнеса</label>
                         <select id="business" name="business">
@@ -344,7 +344,7 @@
                             <option value="other">Другое</option>
                         </select>
                     </div>
-                    
+
                     <div class="form-group">
                         <label for="plan">Выберите пакет участия *</label>
                         <div class="radio-group">
@@ -360,7 +360,7 @@
                             </label>
                         </div>
                     </div>
-                    
+
                     <button type="submit" class="cta-button primary large">
                         Забронировать место
                     </button>
@@ -379,7 +379,7 @@
                 </div>
                 <div class="footer-contact">
                     <h4>Контакты</h4>
-                    <p>Email: info@googlemapsworkshop.com</p>
+                    <p>Email: info@wisdomseducation.com</p>
                     <p>Телефон: +1 (904) 562-9782</p>
                 </div>
             </div>
@@ -390,6 +390,9 @@
     </footer>
 
     <script src="script.js"></script>
+    <!-- Start of HubSpot Embed Code -->
+    <script type="text/javascript" id="hs-script-loader" async defer src="//js.hs-scripts.com/45844889.js"></script>
+    <!-- End of HubSpot Embed Code -->
 </body>
 </html>
 

--- a/script.js
+++ b/script.js
@@ -39,36 +39,42 @@ function updateCountdown() {
 setInterval(updateCountdown, 1000);
 updateCountdown();
 
-// Form submission
-document.getElementById('registrationForm').addEventListener('submit', function(e) {
-    e.preventDefault();
-    
-    // Get form data
-    const formData = new FormData(this);
-    const data = Object.fromEntries(formData);
-    
-    // Simple validation
-    if (!data.name || !data.email || !data.phone || !data.plan) {
-        alert('Пожалуйста, заполните все обязательные поля');
-        return;
-    }
-    
-    // Email validation
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    if (!emailRegex.test(data.email)) {
-        alert('Пожалуйста, введите корректный email адрес');
-        return;
-    }
-    
-    // Show success message
-    alert('Спасибо за регистрацию! Мы свяжемся с вами в ближайшее время для подтверждения участия.');
-    
-    // Reset form
-    this.reset();
-    
-    // In a real application, you would send this data to your server
-    console.log('Registration data:', data);
-});
+// Form submission handler with Formspree integration
+const registrationForm = document.getElementById('registrationForm');
+if (registrationForm) {
+    registrationForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+
+        const formData = new FormData(this);
+        const data = Object.fromEntries(formData);
+
+        if (!data.name || !data.email || !data.phone || !data.plan) {
+            alert('Пожалуйста, заполните все обязательные поля');
+            return;
+        }
+
+        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        if (!emailRegex.test(data.email)) {
+            alert('Пожалуйста, введите корректный email адрес');
+            return;
+        }
+
+        fetch('https://formspree.io/f/xvgrrpan', {
+            method: 'POST',
+            headers: { 'Accept': 'application/json' },
+            body: formData
+        }).then(response => {
+            if (response.ok) {
+                alert('Спасибо за регистрацию! Мы свяжемся с вами в ближайшее время для подтверждения участия.');
+                registrationForm.reset();
+            } else {
+                alert('Произошла ошибка при отправке. Попробуйте еще раз.');
+            }
+        }).catch(() => {
+            alert('Произошла ошибка при отправке. Попробуйте еще раз.');
+        });
+    });
+}
 
 // Scroll animations
 function animateOnScroll() {


### PR DESCRIPTION
## Summary
- bring back the full registration form
- send submissions to Formspree via fetch and keep client-side validation
- embed HubSpot tracking script
- retain updated contact email

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684ce4a3af0883259dc99913bcd999c5